### PR TITLE
Use pool verify hook to avoid concurrent query deprecation warning

### DIFF
--- a/src/pg.ts
+++ b/src/pg.ts
@@ -44,7 +44,19 @@ export default class Pg extends Base {
       this.pool = config.pool;
       this._doNotEnd = true;
     } else {
-      this.pool = new pg.Pool({allowExitOnIdle: true, ...options, ...Pg.parseConfig(config)});
+      this.pool = new pg.Pool({
+        allowExitOnIdle: true,
+        ...options,
+        ...Pg.parseConfig(config),
+        verify: (client: pg.PoolClient, done: (err?: Error) => void) => {
+          if (this.searchPath?.length > 0) {
+            const searchPath = this.searchPath.map(path => client.escapeIdentifier(path)).join(', ');
+            client.query(`SET search_path TO ${searchPath}`, err => done(err ?? undefined));
+          } else {
+            done();
+          }
+        }
+      } as any);
     }
 
     if (options.searchPath !== undefined) this.searchPath = options.searchPath;
@@ -52,13 +64,6 @@ export default class Pg extends Base {
 
     // Convert BIGINT to number (even if not all 64bit are usable)
     pg.types.setTypeParser(20, parseInt);
-
-    this.pool.on('connect', client => {
-      if (this.searchPath.length > 0) {
-        const searchPath = this.searchPath.map(path => client.escapeIdentifier(path)).join(', ');
-        client.query(`SET search_path TO ${searchPath}`);
-      }
-    });
   }
 
   async [Symbol.asyncDispose]() {

--- a/src/pg.ts
+++ b/src/pg.ts
@@ -49,7 +49,7 @@ export default class Pg extends Base {
         ...options,
         ...Pg.parseConfig(config),
         verify: (client: pg.PoolClient, done: (err?: Error) => void) => {
-          if (this.searchPath?.length > 0) {
+          if (this.searchPath.length > 0) {
             const searchPath = this.searchPath.map(path => client.escapeIdentifier(path)).join(', ');
             client.query(`SET search_path TO ${searchPath}`, err => done(err ?? undefined));
           } else {


### PR DESCRIPTION
Calling `client.query()` inside `pool.on('connect')` fires synchronously within pg-pool's `_acquireClient`, right before `pendingItem.callback` runs. This causes two queries to overlap on the same client in the same tick, triggering the pg@8 deprecation warning (and a hard error in pg@9):

```
DeprecationWarning: Calling client.query() when the client is already executing a query
is deprecated and will be removed in pg@9.0.
```

Using the pool's `verify` option instead ensures `SET search_path` completes fully before the client is ever dispatched to callers — no concurrent queries, no warning.